### PR TITLE
fix/readme-link: fixing the readme api reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The Secret Software Development Kit (SDK) in Python is a simple library toolkit 
 
 # API Reference
 
-An intricate reference to the APIs on the Secret SDK can be found <a href="https://api.scrt.network/swagger/">here</a>.
+An intricate reference to the APIs on the Secret SDK can be found <a href="https://docs.scrt.network/secret-network-documentation/development/resources-api-contract-addresses/connecting-to-the-network/testnet-pulsar-3">here</a>.
 
 <br/>
 


### PR DESCRIPTION
This PR closes #8 
- The current API reference for readme directed to a swagger link which did not exists 
- now it redirects to the API reference link to the secret network docs